### PR TITLE
Add acknowledge flow to API, TUI, and WebGUI

### DIFF
--- a/comhairimh.py
+++ b/comhairimh.py
@@ -2,8 +2,9 @@
 
 import datetime
 import enum
+import itertools
 #from typing import Optional
-from fastapi import FastAPI  #, Depends, HTTPException
+from fastapi import FastAPI, HTTPException  #, Depends
 from pydantic import BaseModel
 
 AUTO_ACK = 300
@@ -13,6 +14,8 @@ class Countdown(BaseModel):
     """A single countdown"""
     label: str
     deadline: datetime.datetime
+    id: int | None = None
+    acked: bool = False
     # TODO catalog start time
     #start_time: datetime.datetime
 
@@ -20,13 +23,14 @@ class Countdown(BaseModel):
         """Output countdown with time remaining"""
         now = datetime.datetime.now()
         remaining = max(int((self.deadline - now).total_seconds() / 60), 0)
-        return {'label': self.label,
+        return {'id': self.id,
+                'label': self.label,
                 'deadline': self.deadline,
                 'remaining': remaining}
 
     def is_ack(self):
         """True if countdown has been acknowledged"""
-        return (datetime.datetime.now() - self.deadline).total_seconds() > AUTO_ACK
+        return self.acked or (datetime.datetime.now() - self.deadline).total_seconds() > AUTO_ACK
 
 
 class PomodoroType(str, enum.Enum):
@@ -45,7 +49,14 @@ app = FastAPI(title="Comhairimh API")
 #countdowns = [Countdown(label="Test",
 #                        deadline=datetime.datetime.now() + datetime.timedelta(minutes=25))]
 countdowns = []
+countdown_ids = itertools.count(1)
 current_pom = None
+current_pom_countdown = None
+
+def register_countdown(countdown):
+    """Assign an ID to a countdown and add it to the list"""
+    countdown.id = next(countdown_ids)
+    countdowns.append(countdown)
 
 @app.get("/countdowns/")
 def get_list():
@@ -57,13 +68,22 @@ def get_list():
 @app.post("/countdowns/")
 def add_countdown(countdown: Countdown):
     """Add a new countdown"""
-    countdowns.append(countdown)
+    register_countdown(countdown)
     return countdown.output()
+
+@app.post("/countdowns/{countdown_id}/ack")
+def ack_countdown(countdown_id: int):
+    """Acknowledge a countdown"""
+    for countdown in countdowns:
+        if countdown.id == countdown_id:
+            countdown.acked = True
+            return countdown.output()
+    raise HTTPException(status_code=404, detail="Countdown not found")
 
 @app.post("/pomodoros/")
 def start_pomodoro(pomodoro: Pomodoro):
     """Start a pomodoro"""
-    global current_pom
+    global current_pom, current_pom_countdown
     if pomodoro.pomodoro_type == PomodoroType.next_:
         pomodoro.pomodoro_type = PomodoroType.work
         if current_pom and current_pom.pomodoro_type == PomodoroType.work:
@@ -73,7 +93,10 @@ def start_pomodoro(pomodoro: Pomodoro):
         length = 5
     deadline = datetime.datetime.now() + datetime.timedelta(minutes=length)
     current_pom = pomodoro
+    if current_pom_countdown:
+        current_pom_countdown.acked = True
     countdown = Countdown(label=f"{pomodoro.pomodoro_type.value} pomodoro",
                           deadline=deadline)
-    countdowns.append(countdown)
+    register_countdown(countdown)
+    current_pom_countdown = countdown
     return countdown.output()

--- a/comhairimh_html.py
+++ b/comhairimh_html.py
@@ -36,3 +36,11 @@ def add_timer():
                                                                     datetime.time.fromisoformat(request.form.get('deadline'))).isoformat()})
     res.raise_for_status()
     return redirect(url_for('home'))
+
+@app.post('/ack')
+def ack_timer():
+    """Acknowledge a timer"""
+    res = requests.post(COMHAIRIMH_API + f"countdowns/{request.form.get('id')}/ack",
+                        timeout=5)
+    res.raise_for_status()
+    return redirect(url_for('home'))

--- a/comhairimh_tui.py
+++ b/comhairimh_tui.py
@@ -40,6 +40,12 @@ def add_pomodoro(countdown_list):
                   timeout=1)
     countdown_list.reload()
 
+def ack_countdown(countdown_id, countdown_list):
+    """Acknowledge a countdown"""
+    requests.post(API_URL + f"countdowns/{countdown_id}/ack",
+                  timeout=1)
+    countdown_list.reload()
+
 
 class CardEdit(ModalScreen[str]):
     """Ask user for text of card"""
@@ -99,7 +105,13 @@ class Stopwatch(Horizontal):
     """A stopwatch widget."""
 
     my_name = reactive("")
+    my_id = reactive(None)
     end_time = reactive(datetime.datetime.now())
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Event handler called when a button is pressed."""
+        if event.button.id == "ack":
+            ack_countdown(self.my_id, self.app.query_one(CountdownClocks))
 
 #    def on_button_pressed(self, event: Button.Pressed) -> None:
 #        """Event handler called when a button is pressed."""
@@ -123,6 +135,7 @@ class Stopwatch(Horizontal):
         my_time = TimeDisplay()
         my_time.end_time = self.end_time
         yield my_time
+        yield Button("Ack", id="ack")
 
 class Clock(Digits):
     """A clock that just shows the current time"""
@@ -146,6 +159,7 @@ class CountdownClocks(VerticalScroll):
         for countdown in get_countdowns():
             new_countdown = Stopwatch()
             new_countdown.my_name = countdown["label"]
+            new_countdown.my_id = countdown["id"]
             new_countdown.end_time = datetime.datetime.fromisoformat(countdown["deadline"])
             yield new_countdown
 

--- a/comhairimh_tui.py
+++ b/comhairimh_tui.py
@@ -113,19 +113,6 @@ class Stopwatch(Horizontal):
         if event.button.id == "ack":
             ack_countdown(self.my_id, self.app.query_one(CountdownClocks))
 
-#    def on_button_pressed(self, event: Button.Pressed) -> None:
-#        """Event handler called when a button is pressed."""
-#        button_id = event.button.id
-#        time_display = self.query_one(TimeDisplay)
-#        if button_id == "start":
-#            time_display.start()
-#            self.add_class("started")
-#        elif button_id == "stop":
-#            time_display.stop()
-#            self.remove_class("started")
-#        elif button_id == "reset":
-#            time_display.reset()
-
     def compose(self) -> ComposeResult:
         """Create child widgets of a stopwatch."""
  #       yield Button("Start", id="start", variant="success")
@@ -180,7 +167,8 @@ class StopwatchApp(App):
     BINDINGS = [
         ("a", "add_stopwatch", "Add"),
 #        ("r", "remove_stopwatch", "Remove"),
-        ("p", "start_pomodoro", "Pom")
+        ("p", "start_pomodoro", "Pom"),
+        ("k", "ack_countdown", "Ack")
     ]
 
     def compose(self) -> ComposeResult:
@@ -213,6 +201,12 @@ class StopwatchApp(App):
         """Start the next pomodoro"""
         tgt_list = self.query_one(CountdownClocks)
         add_pomodoro(tgt_list)
+
+    def action_ack_countdown(self) -> None:
+        """Acknowledge the countdown at the top of the list"""
+        timers = self.query(Stopwatch)
+        if timers:
+            ack_countdown(timers.first().my_id, self.query_one(CountdownClocks))
 
     def on_mount(self) -> None:
         """Set the title"""

--- a/stopwatch.tcss
+++ b/stopwatch.tcss
@@ -29,6 +29,10 @@ Button {
     dock: right;
 }
 
+#ack {
+    dock: right;
+}
+
 .started {
     background: $success;
     color: $text;

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -12,7 +12,7 @@
 <body>
 <table>
 {% for timer in timers %}
-<tr><td>{{timer.label}}</td><td>{{timer.remaining}}</td><td></td></tr>
+<tr><td>{{timer.label}}</td><td>{{timer.remaining}}</td><td><form action="{{url_for('ack_timer')}}" method="post"><input type="hidden" name="id" value="{{timer.id}}" /><input type="submit" value="ack" /></form></td></tr>
 {% endfor %}
 <form action="{{url_for('home')}}"><tr>
 	<td></td>


### PR DESCRIPTION
Closes #2.

## What

- **API** (`comhairimh.py`): countdowns now get a server-assigned `id` (included in `GET /countdowns/` output) and an `acked` flag. New endpoint `POST /countdowns/{id}/ack` acknowledges a specific countdown (404 for unknown ids). Starting a new pomodoro auto-acks the previous pomodoro's countdown, per the issue discussion.
- **TUI** (`comhairimh_tui.py`, `stopwatch.tcss`): each timer now has an "Ack" button (docked right) that acks via the API and reloads the list.
- **WebGUI** (`comhairimh_html.py`, `templates/basic.html`): each timer row's empty third column now has an "ack" button posting to a new `/ack` route that forwards to the API.

Manual ack is by id ("ack any"), the second option from the issue comments, since per-row buttons in both frontends need to target a specific timer.

## Testing

- curl against a fresh API instance: add → list shows `id`; ack → removed from list; bogus id → 404; two consecutive pomodoros → first one auto-acked.
- WebGUI: page renders ack button per row; POST `/ack` redirects home with the timer gone.
- TUI: headless Textual pilot clicked the Ack button and confirmed the timer widget disappeared after reload.

Note: in-memory state means deployed instances lose current timers on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BiAUQXofUyCiPUhXRsVBz4