### PR TITLE
Add id-less ack-soonest flow to API, TUI, and WebGUI

### DIFF
--- a/comhairimh.py
+++ b/comhairimh.py
@@ -3,7 +3,7 @@
 import datetime
 import enum
 #from typing import Optional
-from fastapi import FastAPI  #, Depends, HTTPException
+from fastapi import FastAPI, HTTPException  #, Depends
 from pydantic import BaseModel
 
 AUTO_ACK = 300
@@ -13,6 +13,7 @@ class Countdown(BaseModel):
     """A single countdown"""
     label: str
     deadline: datetime.datetime
+    acked: bool = False
     # TODO catalog start time
     #start_time: datetime.datetime
 
@@ -26,7 +27,7 @@ class Countdown(BaseModel):
 
     def is_ack(self):
         """True if countdown has been acknowledged"""
-        return (datetime.datetime.now() - self.deadline).total_seconds() > AUTO_ACK
+        return self.acked or (datetime.datetime.now() - self.deadline).total_seconds() > AUTO_ACK
 
 
 class PomodoroType(str, enum.Enum):
@@ -46,6 +47,7 @@ app = FastAPI(title="Comhairimh API")
 #                        deadline=datetime.datetime.now() + datetime.timedelta(minutes=25))]
 countdowns = []
 current_pom = None
+current_pom_countdown = None
 
 @app.get("/countdowns/")
 def get_list():
@@ -60,10 +62,20 @@ def add_countdown(countdown: Countdown):
     countdowns.append(countdown)
     return countdown.output()
 
+@app.post("/countdowns/ack")
+def ack_countdown():
+    """Acknowledge the soonest or most overdue countdown"""
+    active = [x for x in countdowns if not x.is_ack()]
+    if not active:
+        raise HTTPException(status_code=404, detail="No active countdowns")
+    soonest = min(active, key=lambda y: y.deadline)
+    soonest.acked = True
+    return soonest.output()
+
 @app.post("/pomodoros/")
 def start_pomodoro(pomodoro: Pomodoro):
     """Start a pomodoro"""
-    global current_pom
+    global current_pom, current_pom_countdown
     if pomodoro.pomodoro_type == PomodoroType.next_:
         pomodoro.pomodoro_type = PomodoroType.work
         if current_pom and current_pom.pomodoro_type == PomodoroType.work:
@@ -73,7 +85,10 @@ def start_pomodoro(pomodoro: Pomodoro):
         length = 5
     deadline = datetime.datetime.now() + datetime.timedelta(minutes=length)
     current_pom = pomodoro
+    if current_pom_countdown:
+        current_pom_countdown.acked = True
     countdown = Countdown(label=f"{pomodoro.pomodoro_type.value} pomodoro",
                           deadline=deadline)
     countdowns.append(countdown)
+    current_pom_countdown = countdown
     return countdown.output()

--- a/comhairimh_html.py
+++ b/comhairimh_html.py
@@ -36,3 +36,10 @@ def add_timer():
                                                                     datetime.time.fromisoformat(request.form.get('deadline'))).isoformat()})
     res.raise_for_status()
     return redirect(url_for('home'))
+
+@app.post('/ack')
+def ack_timer():
+    """Acknowledge the soonest timer"""
+    res = requests.post(COMHAIRIMH_API + 'countdowns/ack', timeout=5)
+    res.raise_for_status()
+    return redirect(url_for('home'))

--- a/comhairimh_tui.py
+++ b/comhairimh_tui.py
@@ -40,6 +40,12 @@ def add_pomodoro(countdown_list):
                   timeout=1)
     countdown_list.reload()
 
+def ack_countdown(countdown_list):
+    """Acknowledge the soonest countdown"""
+    requests.post(API_URL + "countdowns/ack",
+                  timeout=1)
+    countdown_list.reload()
+
 
 class CardEdit(ModalScreen[str]):
     """Ask user for text of card"""
@@ -166,7 +172,8 @@ class StopwatchApp(App):
     BINDINGS = [
         ("a", "add_stopwatch", "Add"),
 #        ("r", "remove_stopwatch", "Remove"),
-        ("p", "start_pomodoro", "Pom")
+        ("p", "start_pomodoro", "Pom"),
+        ("k", "ack_countdown", "Ack")
     ]
 
     def compose(self) -> ComposeResult:
@@ -199,6 +206,11 @@ class StopwatchApp(App):
         """Start the next pomodoro"""
         tgt_list = self.query_one(CountdownClocks)
         add_pomodoro(tgt_list)
+
+    def action_ack_countdown(self) -> None:
+        """Acknowledge the soonest countdown"""
+        tgt_list = self.query_one(CountdownClocks)
+        ack_countdown(tgt_list)
 
     def on_mount(self) -> None:
         """Set the title"""

--- a/templates/basic.html
+++ b/templates/basic.html
@@ -12,7 +12,7 @@
 <body>
 <table>
 {% for timer in timers %}
-<tr><td>{{timer.label}}</td><td>{{timer.remaining}}</td><td></td></tr>
+<tr><td>{{timer.label}}</td><td>{{timer.remaining}}</td><td>{% if loop.first %}<form action="{{url_for('ack_timer')}}" method="post"><input type="submit" value="ack" /></form>{% endif %}</td></tr>
 {% endfor %}
 <form action="{{url_for('home')}}"><tr>
 	<td></td>


### PR DESCRIPTION
Closes #2.

This is the simpler alternative to #21 — option (a) from the issue comments ("ack the soonest or most overdue"), so no identifiers are needed anywhere.

## What

- **API** (`comhairimh.py`): countdowns get an `acked` flag. New endpoint `POST /countdowns/ack` acknowledges the active countdown with the earliest deadline — i.e. the soonest upcoming or most overdue one (404 when there are no active countdowns). Starting a new pomodoro auto-acks the previous pomodoro's countdown, per the issue discussion.
- **TUI** (`comhairimh_tui.py`): new `k` binding / footer "Ack" button that acks via the API and reloads the list.
- **WebGUI** (`comhairimh_html.py`, `templates/basic.html`): an "ack" button in the first timer row's empty third column (the list is sorted, so the first row is exactly the timer that will be acked), posting to a new `/ack` route that forwards to the API.

## Testing

- curl against a fresh API instance: add two countdowns → ack returns and removes the soonest; second ack removes the other; ack with nothing active → 404; two consecutive pomodoros → first one auto-acked.
- WebGUI: page renders the ack button only on the first row; POST `/ack` redirects home with the soonest timer gone and the button moved to the new first row.
- TUI: headless Textual pilot pressed `k` and confirmed the soonest timer widget disappeared after reload.

Note: same in-memory-state caveat as #21 — deployed instances lose current timers on restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)